### PR TITLE
ci: forward bump input to reusable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,21 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   release:
     uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
+    with:
+      bump: ${{ inputs.bump }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Declare the `bump` input on `workflow_dispatch` and forward it to the reusable release workflow via `with:`.

Without this, `gh workflow run release.yml --field bump=minor` fails with `Unexpected inputs provided: ["bump"]`, forcing manual tag+bump work outside the workflow.

Tag-push releases are unaffected — `inputs.bump` is empty, which the reusable workflow's bump job treats as skip.