### PR TITLE
feat: ship as npm package via @netresearch/agent-skill-coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ composer require netresearch/file-search-skill
 
 Requires [netresearch/composer-agent-skill-plugin](https://github.com/netresearch/composer-agent-skill-plugin).
 
+### npm (Node Projects)
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/file-search-skill
+```
+
+Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/node-agent-skill-coordinator), which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook. For pnpm, also allowlist the coordinator's postinstall:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
 ## Skill Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@netresearch/file-search-skill",
+  "version": "0.0.0-source",
+  "description": "Netresearch AI skill for efficient code and file search using ripgrep, ast-grep, fd, rga, tokei.",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",
+  "homepage": "https://github.com/netresearch/file-search-skill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netresearch/file-search-skill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/netresearch/file-search-skill/issues"
+  },
+  "keywords": [
+    "ai-agent-skill",
+    "ripgrep",
+    "ast-grep",
+    "code-search",
+    "file-search",
+    "anthropic",
+    "claude-code"
+  ],
+  "aiAgentSkill": "skills/file-search/SKILL.md",
+  "files": [
+    "skills/file-search/",
+    "scripts/",
+    "LICENSE-MIT",
+    "LICENSE-CC-BY-SA-4.0",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "@netresearch/agent-skill-coordinator": "^0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@netresearch/file-search-skill",
   "version": "0.0.0-source",
+  "private": true,
   "description": "Netresearch AI skill for efficient code and file search using ripgrep, ast-grep, fd, rga, tokei.",
   "license": "(MIT AND CC-BY-SA-4.0)",
   "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",


### PR DESCRIPTION
## Summary
- Adds `package.json` so the skill is npm-installable straight from this GitHub repo (no npm-registry publication required to start).
- README gains a parallel **npm (Node Projects)** section under Installation, mirroring the existing **Composer (PHP Projects)** section.

## How discovery works (consumer side)

```bash
npm install --save-dev \
  @netresearch/agent-skill-coordinator \
  github:netresearch/file-search-skill
```

After install, the coordinator's `postinstall` walks `node_modules`, finds this package via `aiAgentSkill: skills/file-search/SKILL.md`, validates the frontmatter, and writes a `<skills_system>` block into the project's `AGENTS.md`. Same shape as the Composer plugin's output.

## Why version stays at `0.0.0-source`

Versioning still lives in git tags and the existing Composer release workflow. A real npm version would be set at publish time; until then, `0.0.0-source` is the standard "this manifest exists for tooling, not as a release marker" placeholder.

## Sibling PRs (merged)
- https://github.com/netresearch/git-workflow-skill/pull/39
- https://github.com/netresearch/github-project-skill/pull/67
- https://github.com/netresearch/security-audit-skill/pull/67

Coordinator: https://github.com/netresearch/node-agent-skill-coordinator (`@netresearch/agent-skill-coordinator@0.1.2`)