### PR TITLE
docs(file-search): add batch & parallelize guidance

### DIFF
--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -46,8 +46,9 @@ scc --wide                          # scc: complexity + COCOMO
 
 1. **Start narrow.** Specify types (`-t`, `--lang`, `-e`), scope dirs, count first (`rg -c`).
 2. **Exclude noise** (`-g '!vendor/'`, `fd -E node_modules`).
-3. **`--json`** for programmatic processing.
-4. **rg ≠ fd types.** `rg -t ts` includes `.tsx`; `fd -e ts` does NOT. No `-t tsx` in rg.
+3. **Batch independent queries.** Union patterns with `rg -e P1 -e P2 -e P3` (one walk, one process), or issue distinct queries as parallel tool calls in a single message — never sequential `&&` chains for independent searches.
+4. **`--json`** for programmatic processing.
+5. **rg ≠ fd types.** `rg -t ts` includes `.tsx`; `fd -e ts` does NOT. No `-t tsx` in rg.
 
 See [references/search-strategies.md](references/search-strategies.md).
 

--- a/skills/file-search/references/search-strategies.md
+++ b/skills/file-search/references/search-strategies.md
@@ -68,3 +68,45 @@ rg -n -C 1 'from requests import' -t py
 rg 'pattern' -g '!vendor/' -g '!node_modules/' -g '!*.min.js' -g '!dist/'
 fd -e py -E __pycache__ -E .venv -E '*.pyc'
 ```
+
+---
+
+## 6. Batch & Parallelize Independent Queries
+
+`rg` walks the filesystem once per invocation. N sequential calls = N walks
++ N startup costs. Two ways to collapse that:
+
+### 6a. Union patterns in one process (`rg -e ... -e ...`)
+
+When you want any of several patterns from the same scope, pass them all
+to one `rg`:
+
+```bash
+# Good: one walk, one process
+rg -t php -e 'RequestHandlerInterface' -e 'MiddlewareInterface' -e 'PSR-15'
+
+# Bad: three walks
+rg -t php 'RequestHandlerInterface'
+rg -t php 'MiddlewareInterface'
+rg -t php 'PSR-15'
+```
+
+Use `-f patterns.txt` for many patterns. Each match line shows which
+pattern hit (use `--json` to get pattern IDs reliably).
+
+### 6b. Parallel tool calls for distinct scopes/intents
+
+When queries differ enough that `-e` union would mix unrelated results
+(different file types, different directories, different post-processing),
+issue them as **parallel tool calls in a single message** rather than
+sequentially. The agent harness runs them concurrently; total wall time
+≈ slowest single call.
+
+Good candidates for parallel calls:
+
+- Different file types: `rg -t php X` + `rg -t js X` + `rg -t ts X`
+- Different directories: `rg X src/` + `rg X tests/` + `rg X docs/`
+- Different tools on same target: `rg X` + `fd -g '*X*'` + `tokei`
+
+Anti-pattern: chaining greps with `&&` in one Bash call when they're
+independent — the shell still runs them sequentially.

--- a/skills/file-search/references/search-strategies.md
+++ b/skills/file-search/references/search-strategies.md
@@ -91,22 +91,35 @@ rg -t php 'MiddlewareInterface'
 rg -t php 'PSR-15'
 ```
 
-Use `-f patterns.txt` for many patterns. Each match line shows which
-pattern hit (use `--json` to get pattern IDs reliably).
+Use `-f patterns.txt` for many patterns. Note: ripgrep does not annotate
+output with which `-e`/`-f` pattern matched — neither plain text nor
+`--json` exposes a stable pattern index. If you need provenance, run
+separate searches or post-process by re-matching the captured text.
 
-### 6b. Parallel tool calls for distinct scopes/intents
+`rg` also accepts multiple `-t` flags and multiple path arguments, so
+prefer batching scope into a single call:
 
-When queries differ enough that `-e` union would mix unrelated results
-(different file types, different directories, different post-processing),
-issue them as **parallel tool calls in a single message** rather than
-sequentially. The agent harness runs them concurrently; total wall time
-≈ slowest single call.
+```bash
+# Good: one walk, multiple types
+rg -t php -t js -t ts 'pattern'
+
+# Good: one walk, multiple paths
+rg 'pattern' src/ tests/ docs/
+```
+
+### 6b. Parallel tool calls for distinct intents
+
+Use parallel tool calls when the queries can't collapse into one `rg`
+invocation — different patterns in different scopes, different tools,
+or different post-processing. Issue them as **parallel tool calls in a
+single message**; the agent harness runs them concurrently and total
+wall time ≈ slowest single call.
 
 Good candidates for parallel calls:
 
-- Different file types: `rg -t php X` + `rg -t js X` + `rg -t ts X`
-- Different directories: `rg X src/` + `rg X tests/` + `rg X docs/`
+- Different patterns in different scopes: `rg 'Error' logs/` + `rg 'TODO' src/`
 - Different tools on same target: `rg X` + `fd -g '*X*'` + `tokei`
+- Different search modes: `rg 'pattern'` + `sg --pattern 'func($$$)'`
 
-Anti-pattern: chaining greps with `&&` in one Bash call when they're
-independent — the shell still runs them sequentially.
+Anti-pattern: chaining independent greps with `&&` in one Bash call —
+the shell still runs them sequentially.


### PR DESCRIPTION
## Summary

- Add Best Practice #3 in `SKILL.md`: batch independent queries via `rg -e P1 -e P2 -e P3` (one walk, one process), or parallel tool calls when scopes differ.
- Add section 6 in `references/search-strategies.md` covering union patterns (6a), parallel tool calls (6b), and the `&&`-chain anti-pattern.

Motivation: ripgrep's per-invocation cost is small (~30 ms warm on a 12k-file repo), but the wins compound across an agent loop that issues many searches per task. The guidance closes a gap the current skill doesn't address explicitly.

No version bump — left for the maintainer's release flow.

## Test plan

- [ ] Render `SKILL.md` and `references/search-strategies.md` to verify formatting (numbered list still renders, code blocks intact).
- [ ] Sanity-check that example commands run as written: `rg -t php -e 'A' -e 'B'` and `rg -f patterns.txt`.