### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "file-search",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Fast codebase search with ripgrep for text patterns, ast-grep for structural code search, plus fd, rga, tokei, and scc",
   "repository": "https://github.com/netresearch/file-search-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires ripgrep (rg). Optional: fd, ast-grep, rga, tokei, scc."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.4.0"
+  version: "1.5.0"
   repository: https://github.com/netresearch/file-search-skill
 allowed-tools: Bash(rg:*) Bash(fd:*) Bash(sg:*) Bash(rga:*) Bash(tokei:*) Bash(scc:*) Read Glob Grep
 ---


### PR DESCRIPTION
## Release v1.5.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/file-search/SKILL.md` frontmatter `metadata.version` from `v1.4.0` to `v1.5.0`.

### Highlights since v1.4.0

- Ships the skill as an npm package via `@netresearch/agent-skill-coordinator` for ecosystem-wide install/update flows.
- Adds a remote-handoff reference guide and corrects `rg` pattern-provenance and parallelism examples.
- Security hardening: CodeQL (actions) + OpenSSF Scorecard wired up, per-job least-privilege permissions, reusable workflows pinned to commit SHA, and Dependabot scoped to GitHub Actions only (Renovate handles composer/npm).
- Houskeeping: hardened `.gitignore`, status badges, package marked `private: true` to prevent accidental publish.

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
