### PR TITLE
feat(file-search): add semgrep coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ practices for searching codebases of any size.
 |------|---------|----------|
 | [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) | Ultra-fast text/regex search | `grep`, `grep -r` |
 | [ast-grep](https://github.com/ast-grep/ast-grep) (`sg`) | Structural/syntax-aware code search | complex regex hacks |
+| [semgrep](https://semgrep.dev/docs) (`semgrep`) | Security/lint rules at scale with taint analysis | hand-rolled regex CI checks |
 | [fd](https://github.com/sharkdp/fd) (`fd`) | Fast file finder | `find` |
 | [ripgrep-all](https://github.com/phiresky/ripgrep-all) (`rga`) | Search PDFs, Office docs, archives | manual text extraction |
 | [tokei](https://github.com/XAMPPRocky/tokei) | Fast code statistics by language | `cloc`, `wc -l` |
@@ -26,6 +27,7 @@ practices for searching codebases of any size.
 - **Use `fd` instead of `find`** for file discovery
 - **Use `rga` instead of `rg`** when searching non-code files (PDFs, Office docs, archives)
 - **Use `sg` instead of regex** when matching code structure
+- **Use `semgrep`** when you want a *catalog* of security/lint rules (taint, registry) — not just a single pattern
 - **Use `tokei` or `scc`** to assess codebase size, not `cloc` or `wc -l`
 - **Always start with targeted, narrow searches** and widen only if needed
 - **Always specify file types/languages** to limit search scope
@@ -96,6 +98,7 @@ skills/file-search/
   references/
     ripgrep-patterns.md             # Extensive rg pattern recipes by use case
     ast-grep-patterns.md            # Structural search patterns by language
+    semgrep-patterns.md             # Security/lint rules, taint mode, registry
     fd-guide.md                     # fd file finder guide
     rga-guide.md                    # ripgrep-all for non-code files
     tool-comparison.md              # Detailed comparison and decision guide

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -21,14 +21,14 @@ Efficient CLI search tools for AI agents.
 | Search text in code files | `rg` (ripgrep) | `grep`, `grep -r` |
 | Find files by name/path | `fd` | `find`, `ls -R` |
 | Structural/syntax-aware code search | `sg` (ast-grep) | regex hacks |
-| Security/lint rules at scale (taint, registry) | `semgrep` | hand-rolled regex CI checks |
+| Apply rule packs (security/lint, taint) | `semgrep` | regex CI checks |
 | Search PDFs, Office docs, archives | `rga` (ripgrep-all) | manual extraction |
 | Count lines of code by language | `tokei` | `cloc`, `wc -l` |
 | Code stats with complexity metrics | `scc` | `cloc`, `tokei` |
 
-**Decision flow:** text/regex → `rg` | code structure / refactor →
-`sg` | apply a *catalog* of security/lint rules → `semgrep` | files by
-name → `fd` | PDFs/archives → `rga` | codebase stats → `tokei`/`scc`
+**Decision flow:** text → `rg` | structural → `sg` | rule packs →
+`semgrep` | filenames → `fd` | PDFs/archives → `rga` | LOC →
+`tokei`/`scc`
 
 ## Quick Examples
 
@@ -36,7 +36,6 @@ name → `fd` | PDFs/archives → `rga` | codebase stats → `tokei`/`scc`
 rg 'def \w+\(' -t py src/          # rg: text search in Python files
 rg -c 'TODO' -t js | wc -l         # rg: count first, then drill down
 sg --pattern 'console.log($$$)' --rewrite 'logger.info($$$)' --lang js  # sg: structural replace
-semgrep --config=p/security-audit --severity=ERROR .  # semgrep: curated rule pack
 fd -g '*.test.ts' --changed-within 1d  # fd: -g for compound suffixes (NOT -e)
 fd -g '*_test.go' -X rg 'func Test'   # fd+rg: find files, verify contents
 rga 'quarterly revenue' docs/       # rga: search inside PDFs/archives
@@ -67,7 +66,7 @@ See [references/remote-handoff.md](references/remote-handoff.md).
 |-------|------|
 | rg flags, patterns, recipes | [references/ripgrep-patterns.md](references/ripgrep-patterns.md) |
 | ast-grep patterns by language | [references/ast-grep-patterns.md](references/ast-grep-patterns.md) |
-| semgrep rules, taint mode, registry | [references/semgrep-patterns.md](references/semgrep-patterns.md) |
+| semgrep rules and taint mode | [references/semgrep-patterns.md](references/semgrep-patterns.md) |
 | fd flags, usage, fd+rg combos | [references/fd-guide.md](references/fd-guide.md) |
 | rga formats, usage, caching | [references/rga-guide.md](references/rga-guide.md) |
 | tokei and scc usage | [references/code-metrics.md](references/code-metrics.md) |

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -2,12 +2,12 @@
 name: file-search
 description: "Use when searching codebases (text, structural/AST, files by name, PDFs/archives, code stats) or building context before a task."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
-compatibility: "Requires ripgrep (rg). Optional: fd, ast-grep, rga, tokei, scc."
+compatibility: "Requires ripgrep (rg). Optional: fd, ast-grep, rga, tokei, scc, semgrep."
 metadata:
   author: Netresearch DTT GmbH
   version: "1.5.0"
   repository: https://github.com/netresearch/file-search-skill
-allowed-tools: Bash(rg:*) Bash(fd:*) Bash(sg:*) Bash(rga:*) Bash(tokei:*) Bash(scc:*) Read Glob Grep
+allowed-tools: Bash(rg:*) Bash(fd:*) Bash(sg:*) Bash(rga:*) Bash(tokei:*) Bash(scc:*) Bash(semgrep:*) Read Glob Grep
 ---
 
 # File Search Skill
@@ -21,13 +21,14 @@ Efficient CLI search tools for AI agents.
 | Search text in code files | `rg` (ripgrep) | `grep`, `grep -r` |
 | Find files by name/path | `fd` | `find`, `ls -R` |
 | Structural/syntax-aware code search | `sg` (ast-grep) | regex hacks |
+| Security/lint rules at scale (taint, registry) | `semgrep` | hand-rolled regex CI checks |
 | Search PDFs, Office docs, archives | `rga` (ripgrep-all) | manual extraction |
 | Count lines of code by language | `tokei` | `cloc`, `wc -l` |
 | Code stats with complexity metrics | `scc` | `cloc`, `tokei` |
 
-**Decision flow:** text/regex → `rg` | code structure (empty catches,
-function sigs, multi-line patterns) → `sg` | files by name → `fd` |
-PDFs/archives → `rga` | codebase stats → `tokei`/`scc`
+**Decision flow:** text/regex → `rg` | code structure / refactor →
+`sg` | apply a *catalog* of security/lint rules → `semgrep` | files by
+name → `fd` | PDFs/archives → `rga` | codebase stats → `tokei`/`scc`
 
 ## Quick Examples
 
@@ -35,6 +36,7 @@ PDFs/archives → `rga` | codebase stats → `tokei`/`scc`
 rg 'def \w+\(' -t py src/          # rg: text search in Python files
 rg -c 'TODO' -t js | wc -l         # rg: count first, then drill down
 sg --pattern 'console.log($$$)' --rewrite 'logger.info($$$)' --lang js  # sg: structural replace
+semgrep --config=p/security-audit --severity=ERROR .  # semgrep: curated rule pack
 fd -g '*.test.ts' --changed-within 1d  # fd: -g for compound suffixes (NOT -e)
 fd -g '*_test.go' -X rg 'func Test'   # fd+rg: find files, verify contents
 rga 'quarterly revenue' docs/       # rga: search inside PDFs/archives
@@ -65,6 +67,7 @@ See [references/remote-handoff.md](references/remote-handoff.md).
 |-------|------|
 | rg flags, patterns, recipes | [references/ripgrep-patterns.md](references/ripgrep-patterns.md) |
 | ast-grep patterns by language | [references/ast-grep-patterns.md](references/ast-grep-patterns.md) |
+| semgrep rules, taint mode, registry | [references/semgrep-patterns.md](references/semgrep-patterns.md) |
 | fd flags, usage, fd+rg combos | [references/fd-guide.md](references/fd-guide.md) |
 | rga formats, usage, caching | [references/rga-guide.md](references/rga-guide.md) |
 | tokei and scc usage | [references/code-metrics.md](references/code-metrics.md) |

--- a/skills/file-search/references/semgrep-patterns.md
+++ b/skills/file-search/references/semgrep-patterns.md
@@ -1,0 +1,135 @@
+# semgrep Pattern Recipes
+
+Rule-driven structural code search with semgrep, focused on security and
+lint patterns. Use when `sg` (ast-grep) is the wrong tool: semgrep ships
+with curated rule packs, supports taint analysis (source → sink dataflow),
+and is the standard for security CI gates.
+
+## semgrep vs ast-grep
+
+| | `sg` (ast-grep) | `semgrep` |
+|--|-----------------|-----------|
+| **Primary use** | Structural search & rewrite | Security/lint rules at scale |
+| **Patterns live in** | CLI flag or YAML | YAML rules (file or registry) |
+| **Rewrite support** | Yes (first-class) | Limited (`autofix:`) |
+| **Taint tracking** | No | Yes (`mode: taint`) |
+| **Rule registry** | No | https://semgrep.dev/r |
+| **Per-language config** | `--lang` flag | `languages:` in rule |
+| **CI integration** | Manual | `semgrep ci` (native) |
+
+**Rule of thumb:** reach for `sg` when you have a structural pattern in
+your head; reach for `semgrep` when you want to apply a *catalog* of
+patterns (OWASP, CWE, framework-specific lints).
+
+## Quick Examples
+
+```bash
+# Apply the curated security rule pack (no local rules needed)
+semgrep --config=auto .
+
+# Run a specific rule pack
+semgrep --config=p/security-audit .
+semgrep --config=p/owasp-top-ten .
+semgrep --config=p/r2c-ci .
+
+# Single inline pattern (ad-hoc, no YAML)
+semgrep -e 'eval(...)' --lang python .
+semgrep -e 'exec($CMD)' -e 'os.system($CMD)' --lang python .
+
+# JSON output for pipelines
+semgrep --config=auto --json --quiet .
+
+# Only report severity ERROR (skip WARNING/INFO)
+semgrep --config=auto --severity=ERROR .
+
+# Limit scope
+semgrep --config=auto --include='*.py' src/
+```
+
+## Inline Patterns by Language
+
+```bash
+# Python: dangerous deserialization
+semgrep -e 'pickle.loads($X)' --lang python .
+semgrep -e 'yaml.load($X)' --lang python .   # missing SafeLoader
+
+# Python: SQL string concatenation
+semgrep -e 'cursor.execute("..." + $X)' --lang python .
+
+# JavaScript/TypeScript: dangerous DOM sinks
+semgrep -e '$EL.innerHTML = $X' --lang js .
+semgrep -e 'document.write($X)' --lang js .
+
+# Go: ignored errors
+semgrep -e '_, _ = $F(...)' --lang go .
+
+# PHP: unsafe shell
+semgrep -e 'shell_exec($X)' --lang php .
+semgrep -e 'eval($X)' --lang php .
+```
+
+## Custom Rule (YAML)
+
+For anything you want to reuse, write a rule file:
+
+```yaml
+# .semgrep/no-eval.yml
+rules:
+  - id: no-eval
+    message: "Avoid eval() — use ast.literal_eval or a parser."
+    severity: ERROR
+    languages: [python]
+    pattern: eval(...)
+```
+
+Run it:
+
+```bash
+semgrep --config=.semgrep/ .
+```
+
+## Taint Mode (Dataflow)
+
+Use when you need to track that *user input* flows into a *dangerous
+sink*. Pattern-only matches miss this; taint mode tracks it across
+assignments and function calls.
+
+```yaml
+# .semgrep/sql-injection.yml
+rules:
+  - id: sql-from-request
+    mode: taint
+    message: "User input flows into raw SQL."
+    severity: ERROR
+    languages: [python]
+    pattern-sources:
+      - pattern: request.args.get($X)
+      - pattern: request.form.get($X)
+    pattern-sinks:
+      - pattern: cursor.execute($Q)
+```
+
+## CI Integration
+
+```bash
+# Fail the build on findings of severity ERROR
+semgrep --config=auto --severity=ERROR --error .
+
+# Diff-aware: only scan changed lines (fast CI mode)
+semgrep ci --baseline-ref=origin/main
+```
+
+## When NOT to Use semgrep
+
+- **Free-form text search** → use `rg` instead. semgrep parses code; it
+  cannot match log lines, strings in YAML, or arbitrary text.
+- **One-off structural refactor with a rewrite** → use `sg` instead. Its
+  `--rewrite` is first-class; semgrep autofix is more constrained.
+- **Files semgrep cannot parse** → semgrep skips them silently. If you
+  see "Scan skipped" warnings, fall back to `rg`/`sg`.
+
+## Further Reading
+
+- semgrep docs: https://semgrep.dev/docs
+- Rule registry: https://semgrep.dev/r
+- Writing rules: https://semgrep.dev/docs/writing-rules/overview

--- a/skills/file-search/references/semgrep-patterns.md
+++ b/skills/file-search/references/semgrep-patterns.md
@@ -60,8 +60,8 @@ semgrep -e 'cursor.execute("..." + $X)' --lang python .
 semgrep -e '$EL.innerHTML = $X' --lang js .
 semgrep -e 'document.write($X)' --lang js .
 
-# Go: ignored errors
-semgrep -e '_, _ = $F(...)' --lang go .
+# Go: ignored errors (both assignment and short-declaration forms)
+semgrep -e '_, _ = $F(...)' -e '_, _ := $F(...)' --lang go .
 
 # PHP: unsafe shell
 semgrep -e 'shell_exec($X)' --lang php .
@@ -121,12 +121,14 @@ semgrep ci --baseline-ref=origin/main
 
 ## When NOT to Use semgrep
 
-- **Free-form text search** → use `rg` instead. semgrep parses code; it
-  cannot match log lines, strings in YAML, or arbitrary text.
+- **Unstructured text search** → use `rg` instead. semgrep parses code
+  (and structured formats like YAML/JSON); it cannot match log lines or
+  free-form prose.
 - **One-off structural refactor with a rewrite** → use `sg` instead. Its
   `--rewrite` is first-class; semgrep autofix is more constrained.
-- **Files semgrep cannot parse** → semgrep skips them silently. If you
-  see "Scan skipped" warnings, fall back to `rg`/`sg`.
+- **Files semgrep cannot parse** → semgrep reports parse errors on
+  stderr but produces no findings for those files. If a file is
+  unsupported or unparseable, fall back to `rg`/`sg`.
 
 ## Further Reading
 

--- a/skills/file-search/references/tool-comparison.md
+++ b/skills/file-search/references/tool-comparison.md
@@ -19,7 +19,12 @@ What are you trying to do?
 |   |   --> Use rga (ripgrep-all)
 |   |
 |   |-- Need to match CODE STRUCTURE (not just text)?
-|       --> Use sg (ast-grep)
+|       |
+|       |-- One-off structural pattern / refactor?
+|       |   --> Use sg (ast-grep)
+|       |
+|       |-- Apply a CATALOG of security/lint rules (with dataflow)?
+|           --> Use semgrep
 |
 |-- Find FILES by name, path, or attributes?
 |   --> Use fd
@@ -74,6 +79,16 @@ What are you trying to do?
 - Finding anti-patterns or code smells structurally
 - You need to ignore comments and whitespace in matches
 - Regex would be too fragile for the code pattern
+
+**Choose semgrep when:**
+- Applying a curated rule pack (OWASP, CWE, framework-specific)
+- You need taint analysis (source → sink dataflow), not just pattern match
+- Wiring a security/lint gate into CI (`semgrep ci`)
+- Maintaining a reusable rule library in YAML across the team
+- The pattern is meaningless without severity/message metadata
+
+For inline patterns and recipes, see
+[references/semgrep-patterns.md](semgrep-patterns.md).
 
 ---
 
@@ -201,7 +216,7 @@ sudo apt install ripgrep fd-find
 # Note: fd binary is 'fdfind' on Debian/Ubuntu, alias to 'fd'
 
 # macOS (Homebrew)
-brew install ripgrep fd ast-grep ripgrep-all tokei scc
+brew install ripgrep fd ast-grep ripgrep-all tokei scc semgrep
 
 # Cargo (Rust)
 cargo install ripgrep fd-find ast-grep tokei
@@ -211,6 +226,9 @@ go install github.com/boyter/scc/v3@latest
 
 # npm (ast-grep)
 npm install -g @ast-grep/cli
+
+# pipx (semgrep — Python-based)
+pipx install semgrep
 ```
 
 ---
@@ -219,6 +237,7 @@ npm install -g @ast-grep/cli
 
 - ripgrep: https://github.com/BurntSushi/ripgrep
 - ast-grep: https://github.com/ast-grep/ast-grep
+- semgrep: https://semgrep.dev/docs
 - fd: https://github.com/sharkdp/fd
 - rga: https://github.com/phiresky/ripgrep-all
 - tokei: https://github.com/XAMPPRocky/tokei


### PR DESCRIPTION
## Summary

`semgrep` was the only one of the eight commonly-reviewed search / structural-analysis tools (`rg`, `fd`, `ast-grep`, `semgrep`, `rga`, `tokei`, `scc`, `ctags`) missing from this skill. This PR closes that gap.

It positions `semgrep` as the complement to `sg` (ast-grep), not as a replacement:

- `sg` → ad-hoc structural patterns, refactors, rewrites
- `semgrep` → applying a *catalog* of security/lint rules (OWASP/CWE), taint analysis (source → sink dataflow), and native CI integration (`semgrep ci`)

## Changes

- **New** `references/semgrep-patterns.md` — guide with inline patterns by language, custom YAML rules, taint mode, CI integration, and a "When NOT to use semgrep" section
- `SKILL.md` — extend tool selection table, decision flow, quick examples, references table; add `semgrep` to `compatibility:` and `allowed-tools:`
- `references/tool-comparison.md` — branch the decision flowchart between `sg` and `semgrep`, add a "Choose semgrep when" block, list semgrep in install + further-reading
- `README.md` — add semgrep to the Tools Covered table, Key Principles, and the Skill Structure tree

## Test plan

- [x] Frontmatter (`name`, `description`, `compatibility`, `metadata`, `allowed-tools`) still valid YAML
- [x] All new internal links resolve (`references/semgrep-patterns.md` referenced from SKILL.md + tool-comparison.md)
- [ ] CI: lint + harness-verify + eval-validate green
- [ ] Manual: `semgrep --config=auto .` works from a clean checkout