### PR TITLE
chore(ci): use @main for intra-org reusable workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,10 +34,8 @@ jobs:
     # the workflows themselves for misconfigurations (script injection,
     # missing permissions, vulnerable action SHAs).
     # Push/PR only — CodeQL on workflow files runs on changes, not on cron.
-    # Pinned to a commit SHA per OpenSSF Scorecard "Pinned-Dependencies"
-    # guidance (Renovate keeps the pin current).
     if: github.event_name != 'schedule'
-    uses: netresearch/.github/.github/workflows/codeql.yml@6b38d22ebd3d89c68ca7a32809d8e44acf94e7cc # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
@@ -47,10 +45,8 @@ jobs:
     # OpenSSF Scorecard runs once a week and on default-branch pushes;
     # PRs are skipped because Scorecard requires write tokens we don't
     # want to grant to fork-originated PRs.
-    # Pinned to a commit SHA per OpenSSF Scorecard "Pinned-Dependencies"
-    # guidance (Renovate keeps the pin current).
     if: github.event_name != 'pull_request'
-    uses: netresearch/.github/.github/workflows/scorecard.yml@6b38d22ebd3d89c68ca7a32809d8e44acf94e7cc # main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## What

Switches the `codeql` and `scorecard` jobs in `.github/workflows/security.yml` from digest pins of `netresearch/.github` to `@main`, and removes the two now-inaccurate "Pinned to a commit SHA per OpenSSF Scorecard" comment blocks.

## Why

First-party Netresearch reusable workflows are referenced by `@main`, not by commit SHA — SHA/digest pinning is reserved for third-party actions. The other three intra-org references in this same file (`auto-merge-deps`, `gitleaks`, `dependency-review`) already use `@main`, so the two digest-pinned jobs were an inconsistency rather than a deliberate policy. Those pins were also the sole source of the recurring Renovate digest PRs against this repo (most recently #55). Moving them to `@main` makes all five references consistent and stops the churn — `renovate.json` needs no change.

## Tradeoff

This slightly lowers the OpenSSF Scorecard "Pinned-Dependencies" sub-score for these two refs. That is the accepted house position for first-party reusable workflows: three of five refs were already unpinned, so the score impact was already present, and consistency + zero churn outweigh pinning two of five.