### PR TITLE
chore(release): v1.6.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "file-search",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Fast codebase search with ripgrep for text patterns, ast-grep for structural code search, plus fd, rga, tokei, and scc",
   "repository": "https://github.com/netresearch/file-search-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires ripgrep (rg). Optional: fd, ast-grep, rga, tokei, scc, semgrep."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.6.0"
+  version: "1.6.1"
   repository: https://github.com/netresearch/file-search-skill
 allowed-tools: Bash(rg:*) Bash(fd:*) Bash(sg:*) Bash(rga:*) Bash(tokei:*) Bash(scc:*) Bash(semgrep:*) Read Glob Grep
 ---


### PR DESCRIPTION
Release v1.6.1 (version bump only). 2 file(s) bumped: plugin.json + SKILL.md.