### PR TITLE
chore(release): v1.6.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "file-search",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Fast codebase search with ripgrep for text patterns, ast-grep for structural code search, plus fd, rga, tokei, and scc",
   "repository": "https://github.com/netresearch/file-search-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires ripgrep (rg). Optional: fd, ast-grep, rga, tokei, scc, semgrep."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.6.1"
+  version: "1.6.2"
   repository: https://github.com/netresearch/file-search-skill
 allowed-tools: Bash(rg:*) Bash(fd:*) Bash(sg:*) Bash(rga:*) Bash(tokei:*) Bash(scc:*) Bash(semgrep:*) Read Glob Grep
 ---


### PR DESCRIPTION
- Bump plugin.json and SKILL.md metadata.version to 1.6.2

Changes since v1.6.1:
- docs(file-search): delete duplicate tool-comparison.md, point to cli-tools
- docs(file-search): restore semgrep-patterns.md references, fix link text
- docs(file-search): restore fdfind alias gotcha in fd-guide.md