### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "file-search",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Fast codebase search with ripgrep for text patterns, ast-grep for structural code search, plus fd, rga, tokei, and scc",
   "repository": "https://github.com/netresearch/file-search-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "file-search",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Fast codebase search with ripgrep for text patterns, ast-grep for structural code search, plus fd, rga, tokei, and scc",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires ripgrep (rg). Optional: fd, ast-grep, rga, tokei, scc, semgrep."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.6.2"
+  version: "1.7.0"
   repository: https://github.com/netresearch/file-search-skill
 allowed-tools: Bash(rg:*) Bash(fd:*) Bash(sg:*) Bash(rga:*) Bash(tokei:*) Bash(scc:*) Bash(semgrep:*) Read Glob Grep
 ---


### PR DESCRIPTION
Release v1.7.0.

Version bump only.

Bumped: root `plugin.json`, `.claude-plugin/plugin.json`, every `skills/*/SKILL.md` frontmatter version. Parity verified with `check-version-parity.sh v1.7.0`.

Tag `v1.7.0` follows once this merges.