### PR TITLE
feat(hook): ship the search-tool nudge with the plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 ├── composer.json                       # PHP package metadata
 ├── docs/
 │   └── ARCHITECTURE.md                 # Architecture overview
+├── hooks/hooks.json                    # Registers the PreToolUse search nudge (ships with the plugin)
 ├── scripts/
 │   └── verify-harness.sh              # Harness verification script
 └── README.md

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Points shell searches at the search tools — warns once per rule per session when grep/find is used where rg/fd or the Grep/Glob tools fit",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pre_bash_search_nudge.py",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/pre_bash_search_nudge.py
+++ b/scripts/pre_bash_search_nudge.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""PreToolUse hook for Bash: point shell searches at the search tools.
+
+This skill's table — `rg` instead of `grep`/`grep -r`, `fd` instead of `find`,
+`sg` for structural patterns — is an instruction, and instructions get skipped.
+In the retro that produced this hook, Bash carried 63% of all tool calls while
+the dedicated Grep and Glob tools went unused.
+
+Warn-only, and once per rule per session. The value sits in the first firing:
+it is read once and either changes the next command or has a deliberate reason
+not to — batching several searches into one call, or probing a scratch file.
+Firings 2..n change nothing and only cost the reader attention while scrolling
+(measured on the source machine: 23 firings of these three rules in a single
+session).
+
+Exit code is always 0; a hook that crashes must never block a shell.
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+
+# Structured data belongs to the data-tools gate, which denies extraction from
+# it. Staying out of that lane keeps one command from collecting two messages.
+STRUCT = re.compile(r"\.(json|jsonl|ya?ml|toml|xml|csv|tsv)(\b|['\"])", re.IGNORECASE)
+
+# A quoted heredoc body is data being written, not a command being run.
+QUOTED_HEREDOC = re.compile(r"<<-?\s*(['\"])(\w+)\1.*?^\2$", re.DOTALL | re.MULTILINE)
+
+
+# Prose passed as an option value is text ABOUT commands (a PR body, a commit
+# message), so it must not be scanned for commands. `--body-file` names a path
+# and is left alone.
+def _quoted(group: str) -> str:
+    return rf"(?P<{group}>['\"])(?:\\.|(?!(?P={group})).)*(?P={group})"
+
+
+OPTION_VALUES = (
+    re.compile(
+        r"(?:--(?:body|message|notes|description|title|comment)(?!-file)"
+        r"|(?<!\w)-[mF](?!\w))[= ]\s*" + _quoted("q"),
+        re.DOTALL,
+    ),
+    re.compile(r"(?<!\w)-f\s+\w+=\s*" + _quoted("q"), re.DOTALL),
+)
+ECHOES_TEXT = re.compile(r"^\s*(echo|printf)\b")
+
+RECURSIVE_GREP = re.compile(r"(^|[|&;])\s*grep\s+-[a-zA-Z]*[rR]")
+PLAIN_GREP = re.compile(r"^\s*grep\s")
+FIND = re.compile(r"^\s*find\s")
+
+
+def executable_text(cmd: str) -> str:
+    """The command with its data parts (heredocs, prose option values) removed."""
+    cmd = QUOTED_HEREDOC.sub(" ", cmd or "")
+    for pattern in OPTION_VALUES:
+        cmd = pattern.sub(" ", cmd)
+    return cmd
+
+
+def detect(cmd: str) -> list[str]:
+    """Ordered, de-duplicated nudges for one command string."""
+    cmd = executable_text(cmd)
+    if ECHOES_TEXT.match(cmd.strip()):
+        return []
+    nudges: list[str] = []
+    structured = bool(STRUCT.search(cmd))
+
+    if FIND.match(cmd):
+        nudges.append(
+            "`find` — use the Glob tool, or `fd` (faster, .gitignore-aware, sane defaults)."
+        )
+    if not structured:
+        if RECURSIVE_GREP.search(cmd):
+            nudges.append(
+                "recursive grep over code — use the Grep tool or `rg` (respects .gitignore, "
+                "faster); for structural or multi-language patterns `sg` (ast-grep)."
+            )
+        elif PLAIN_GREP.match(cmd):
+            nudges.append("plain grep — prefer the Grep tool or `rg`.")
+    return nudges
+
+
+# ─── once-per-session dedup ──────────────────────────────────────────────────
+
+
+def _session_key(payload: dict) -> str:
+    """A filename-safe digest of the session identity, or "" when there is none.
+
+    The raw identifier comes from the harness payload and is hashed rather than
+    interpolated: a value carrying `/` or `..` would otherwise steer the state
+    file out of the temp directory.
+    """
+    raw = payload.get("session_id") or os.path.basename(
+        payload.get("transcript_path") or ""
+    )
+    raw = str(raw).strip()
+    if not raw:
+        return ""
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def first_per_session(nudges: list[str], payload: dict) -> list[str]:
+    """Keep only nudges whose rule has not fired in this session yet.
+
+    Without a session identity, or when the state cannot be read or written,
+    this fails OPEN — a broken temp dir must never swallow the first firing.
+    """
+    key = _session_key(payload)
+    if not key:
+        return nudges
+    path = os.path.join(tempfile.gettempdir(), f"file-search-hook-seen-{key}.json")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            seen = set(json.load(fh))
+    except (OSError, ValueError):
+        seen = set()
+    fresh = []
+    for n in nudges:
+        h = hashlib.sha256(n.encode("utf-8")).hexdigest()[:12]
+        if h in seen:
+            continue
+        seen.add(h)
+        fresh.append(n)
+    if fresh:
+        try:
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(sorted(seen), fh)
+        except OSError:
+            pass
+    return fresh
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (ValueError, OSError):
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command", "")
+    if not cmd:
+        return 0
+
+    nudges = first_per_session(detect(cmd), payload)
+    if nudges:
+        print(
+            json.dumps(
+                {
+                    "systemMessage": "file-search: "
+                    + " ".join(nudges)
+                    + " (warned once per rule per session)",
+                    "suppressOutput": True,
+                }
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_pre_bash_search_nudge.py
+++ b/scripts/test_pre_bash_search_nudge.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Cases for scripts/pre_bash_search_nudge.py — run it, read what it says."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import uuid
+
+HOOK = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "pre_bash_search_nudge.py"
+)
+
+# (name, expected substring or None, command)
+CASES = [
+    ("find nudgt auf Glob/fd", "fd", "find . -name '*.ts'"),
+    ("rekursives grep nudgt auf rg", "rg", "grep -rn TODO src/"),
+    ("einfaches grep nudgt", "Grep tool", "grep TODO notes.txt"),
+    # A pipe into grep filters another command's output — that is not a search
+    # over the tree and rg would not replace it.
+    ("grep hinter einer Pipe nudgt nicht", None, "gh pr list | grep open"),
+    # Structured data belongs to the data-tools gate; two hooks must not both
+    # speak up for one command.
+    ("grep auf .json ueberlassen wir data-tools", None, "grep -rn name pkg.json"),
+    ("rg selbst nudgt nicht", None, "rg TODO src/"),
+    ("fd selbst nudgt nicht", None, "fd -e ts"),
+    # Prose about commands is not a command.
+    (
+        "Muster nur im PR-Body",
+        None,
+        """gh pr create --body "use find . -name x instead" """,
+    ),
+    ("Muster nur in echo", None, """echo "find . -name '*.ts'" """),
+    (
+        "Muster nur in gh api -f body=",
+        None,
+        """gh api repos/o/r/issues/1/comments -f body='we ran grep -rn TODO src/'""",
+    ),
+]
+
+
+def run(cmd: str, session_id: str | None = None) -> str:
+    payload = {"tool_name": "Bash", "tool_input": {"command": cmd}}
+    if session_id is not None:
+        payload["session_id"] = session_id
+    p = subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return p.stdout
+
+
+def main() -> int:
+    fails = 0
+    sid = f"test-{uuid.uuid4()}"
+    try:
+        for name, want, cmd in CASES:
+            out = run(cmd, f"{sid}-{uuid.uuid4()}")
+            got = (want in out) if want else ("systemMessage" not in out)
+            fails += 0 if got else 1
+            print(
+                f"  {'OK  ' if got else 'FEHL'} {name:44} erwartet={want or 'still':12} ok={got}"
+            )
+
+        # Dedup: one message per rule per session, a new session speaks again.
+        first = "systemMessage" in run("grep -rn A src/", sid)
+        second = "systemMessage" in run("grep -rn B lib/", sid)
+        other_rule = "systemMessage" in run("find . -name '*.py'", sid)
+        new_session = "systemMessage" in run("grep -rn A src/", f"{sid}-2")
+        for name, want, got in (
+            ("erste Warnung feuert", True, first),
+            ("zweite Warnung derselben Regel schweigt", False, second),
+            ("andere Regel feuert weiterhin", True, other_rule),
+            ("neue Session warnt wieder", True, new_session),
+        ):
+            ok = got == want
+            fails += 0 if ok else 1
+            print(
+                f"  {'OK  ' if ok else 'FEHL'} {name:44} erwartet={want!s:12} erhalten={got}"
+            )
+
+        # A session id carrying separators must not steer the state file out of
+        # the temp directory.
+        run("grep -rn A src/", "../../../../tmp/evil-search")
+        escaped = os.path.exists("/tmp/evil-search")
+        ok = not escaped
+        fails += 0 if ok else 1
+        print(
+            f"  {'OK  ' if ok else 'FEHL'} {'Pfad-Traversal in der Session-ID':44} "
+            f"erwartet=False        erhalten={escaped}"
+        )
+    finally:
+        for stale in os.listdir(tempfile.gettempdir()):
+            if stale.startswith("file-search-hook-seen-"):
+                os.unlink(os.path.join(tempfile.gettempdir(), stale))
+
+    print("  ---- Fehlschlaege:", fails)
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/file-search/SKILL.md
+++ b/skills/file-search/SKILL.md
@@ -47,7 +47,7 @@ scc --wide                          # scc: complexity + COCOMO
 
 1. **Start narrow.** Specify types (`-t`, `--lang`, `-e`), scope dirs, count first (`rg -c`).
 2. **Exclude noise** (`-g '!vendor/'`, `fd -E node_modules`).
-3. **Batch independent queries.** Union patterns with `rg -e P1 -e P2 -e P3` (one walk, one process), or issue distinct queries as parallel tool calls in a single message — never sequential `&&` chains for independent searches.
+3. **Batch independent queries.** Union patterns with `rg -e P1 -e P2 -e P3` (one walk), or issue distinct queries as parallel tool calls in one message — never sequential `&&` chains.
 4. **`--json`** for programmatic processing.
 5. **rg ≠ fd types.** `rg -t ts` includes `.tsx`; `fd -e ts` does NOT. No `-t tsx` in rg.
 
@@ -70,6 +70,7 @@ See [references/remote-handoff.md](references/remote-handoff.md).
 | fd flags, usage, fd+rg combos | [references/fd-guide.md](references/fd-guide.md) |
 | rga formats, usage, caching | [references/rga-guide.md](references/rga-guide.md) |
 | tokei and scc usage | [references/code-metrics.md](references/code-metrics.md) |
+| PreToolUse nudge (ships with plugin) | [references/enforcement-hook.md](references/enforcement-hook.md) |
 | Search targeting strategies | [references/search-strategies.md](references/search-strategies.md) |
 | Remote context handoff guide | [references/remote-handoff.md](references/remote-handoff.md) |
 | Modern CLI tools comparison (legacy→modern, all domains) | [cli-tools-skill/SKILL.md#preferred-modern-tools](https://github.com/netresearch/cli-tools-skill/blob/main/skills/cli-tools/SKILL.md#preferred-modern-tools) |

--- a/skills/file-search/references/enforcement-hook.md
+++ b/skills/file-search/references/enforcement-hook.md
@@ -1,0 +1,52 @@
+# Enforcement Hook
+
+This skill's tool table — `rg` instead of `grep`, `fd` instead of `find`, `sg`
+for structural patterns — is an instruction, and instructions get skipped. The
+reminder that makes it stick **ships with this plugin**: `hooks/hooks.json`
+registers `scripts/pre_bash_search_nudge.py` as a `PreToolUse` hook on `Bash`.
+Installing the plugin installs it; there is no per-machine setup and no copy to
+keep in sync.
+
+The retro that produced it measured the problem: Bash carried 63% of all tool
+calls in a session while the dedicated Grep and Glob tools went unused.
+
+## What it says, and how often
+
+Three rules, all **warn-only** — a shell search is never wrong enough to block:
+
+| Command shape | Message |
+|---|---|
+| `find …` | use the Glob tool, or `fd` |
+| `grep -r` / `grep -R` | use the Grep tool or `rg`; `sg` for structural patterns |
+| `grep …` as the first command | prefer the Grep tool or `rg` |
+
+Each rule speaks **once per session**. The value sits in the first firing: it is
+read once and either changes the next command or has a deliberate reason not to
+— several searches batched into one call, or a probe against a scratch file.
+Firings 2..n change nothing and only cost the reader attention while scrolling
+(measured on the source machine: 23 firings of these three rules in one
+session).
+
+## What it deliberately stays out of
+
+- **A pipe into grep** (`gh pr list | grep open`) filters another command's
+  output. That is not a search over the tree, and `rg` would not replace it.
+- **Structured files** (`.json`, `.yaml`, `.toml`, `.csv`, …). The `data-tools`
+  plugin ships its own gate for those, which *denies* field extraction. Two
+  hooks must not both speak up for one command.
+- **Prose about commands** — a PR body, a commit message, an `echo`. Option
+  values carrying text (`--body`, `-m`, `-f body=`) are stripped before the
+  scan; `--body-file` names a path and is left alone.
+
+## Verify
+
+```bash
+H="$CLAUDE_PLUGIN_ROOT/scripts/pre_bash_search_nudge.py"   # or the plugin cache path
+echo '{"tool_name":"Bash","tool_input":{"command":"find . -name x"}}'    | python3 "$H"  # warns
+echo '{"tool_name":"Bash","tool_input":{"command":"rg TODO src/"}}'      | python3 "$H"  # silent
+```
+
+The full case list runs as `python3 scripts/test_pre_bash_search_nudge.py`.
+
+If nothing happens on a real `find .`, the plugin's hooks have not been picked
+up — open `/hooks` once, or restart the session.


### PR DESCRIPTION
The tool table in `SKILL.md` — ripgrep instead of grep, fd instead of find, ast-grep for structural patterns — is an instruction, and instructions get skipped. The retro behind this measured the gap: Bash carried 63% of all tool calls in a session while the dedicated Grep and Glob tools went unused.

`hooks/hooks.json` now registers `scripts/pre_bash_search_nudge.py` as a `PreToolUse` hook on Bash — the same layout `cli-tools` and `data-tools` use. Installing the plugin installs the reminder; there is no per-machine setup and no copy to keep in sync.

Three rules, all warn-only, because a shell search is never wrong enough to block: a find invocation, a recursive grep, and a plain grep as the first command. Each speaks **once per session**. The first firing carries the information and either changes the next command or has a deliberate reason not to; firings two through n change nothing and only cost the reader attention while scrolling. On the source machine those three rules fired 23 times in a single session, which is what prompted the cap.

Three deliberate silences, each a false positive first: a pipe into grep filters another command's output rather than searching a tree, so ripgrep would not replace it; structured files belong to the `data-tools` gate, which denies extraction from them, so one command never collects two messages from two plugins; and prose about commands — a PR body, a commit message, an echo, a `-f body=` field — is stripped before the scan, while an option naming a file is left alone.

The session identity is hashed before it becomes part of the dedup state file's name, so a value carrying a path separator cannot steer that file out of the temp directory.

Test plan: 15 cases in `scripts/test_pre_bash_search_nudge.py` covering every rule, every silence, dedup across sessions and rules, and the path-traversal guard — all green. ruff check and format green, markdownlint green, skill validation and version parity green via pre-commit. SKILL.md is at the 500-word cap.

https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss
